### PR TITLE
[WIP] Pandas dynamically create StringDtype aliases 

### DIFF
--- a/src/visions/__init__.py
+++ b/src/visions/__init__.py
@@ -1,6 +1,11 @@
 """Core functionality"""
+import pandas as pd
+
 from visions import types, typesets, utils
-from visions.dtypes.boolean import BoolDtype
+
+if pd.__version__.split(".")[0] == 0:
+    from visions.dtypes.boolean import BoolDtype
+
 from visions.functional import (
     cast_frame,
     cast_series,

--- a/src/visions/dtypes/stringdtype_alias.py
+++ b/src/visions/dtypes/stringdtype_alias.py
@@ -1,0 +1,33 @@
+from typing import Type
+
+from pandas import StringDtype
+from pandas.core.arrays import StringArray
+from pandas.core.dtypes.dtypes import registry
+
+
+def create_alias(name: str) -> Type[StringDtype]:
+    # Note that isinstance([Name]Dtype(), StringDtype()) == True
+
+    # @classmethod
+    # def _from_sequence(cls, scalars, dtype=None, copy=False):
+    #     return super()._from_sequence(scalars, copy=copy)
+    snake_name = "".join([part.capitalize() for part in name.split("_")])
+    dtype = f"{snake_name}Dtype"
+    arr = f"{snake_name}Array"
+
+    alias_dtype = type(
+        dtype, (StringDtype,), {"name": name, "__repr__": lambda self: dtype}
+    )
+
+    alias_array = type(arr, (StringArray,), {})
+
+    def constructor(self, values, copy=False):
+        super(alias_array, self).__init__(values, copy)
+        self._dtype = alias_dtype()
+
+    alias_array.__init__ = constructor
+    alias_dtype.construct_array_type = classmethod(lambda cls: alias_array)
+
+    registry.register(alias_dtype)
+
+    return alias_dtype

--- a/src/visions/types/email_address.py
+++ b/src/visions/types/email_address.py
@@ -15,10 +15,8 @@ EmailDtype = create_alias("email")
 def str_to_email(s):
     if isinstance(s, FQDA):
         return s
-
     if isinstance(s, str):
         return FQDA(*s.split("@", maxsplit=1))
-
     return None
 
 

--- a/src/visions/types/file.py
+++ b/src/visions/types/file.py
@@ -1,3 +1,5 @@
+import os
+
 import pathlib
 from typing import Sequence
 
@@ -19,9 +21,7 @@ def _get_relations(cls) -> Sequence[TypeRelation]:
         InferenceRelation(
             cls,
             Path,
-            relationship=lambda series: all(
-                isinstance(p, pathlib.Path) and p.exists() for p in series
-            ),
+            relationship=lambda series: all(os.path.exists(p) for p in series),
             transformer=lambda series: series.astype("file"),
         ),
     ]


### PR DESCRIPTION
Pandas dynamically create StringDtype aliases (such as FileDtype) to cache membership checks.

See #76.