### PR TITLE
Integer consistency for standard set

### DIFF
--- a/src/visions/types/count.py
+++ b/src/visions/types/count.py
@@ -8,9 +8,9 @@ from visions.types.type import VisionsBaseType
 
 
 def _get_relations(cls) -> Sequence[TypeRelation]:
-    from visions.types import Generic
+    from visions.types import Integer
 
-    relations = [IdentityRelation(cls, Generic)]
+    relations = [IdentityRelation(cls, Integer)]
     return relations
 
 

--- a/src/visions/types/integer.py
+++ b/src/visions/types/integer.py
@@ -11,7 +11,7 @@ from visions.utils.coercion import test_utils
 
 def to_int(series: pd.Series) -> pd.Series:
     try:
-        return series.astype(int)
+        return series.astype(np.int64)
     except ValueError:
         return series.astype("Int64")
 
@@ -62,4 +62,4 @@ class Integer(VisionsBaseType):
 
     @classmethod
     def contains_op(cls, series: pd.Series) -> bool:
-        return pdt.is_signed_integer_dtype(series)
+        return pdt.is_integer_dtype(series)

--- a/tests/series.py
+++ b/tests/series.py
@@ -25,6 +25,7 @@ def get_series():
         pd.Series([1, 0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0], name="int_series_boolean"),
         # Count
         pd.Series(np.array([1, 2, 3, 4], dtype=np.uint32), name="np_uint32"),
+        pd.Series(np.array([1, 2, 3, 4], dtype="UInt32"), name="pd_uint32"),
         # Categorical
         pd.Series([1, 2, 3], name="categorical_int_series", dtype="category"),
         pd.Series(

--- a/tests/typesets/test_complete_set.py
+++ b/tests/typesets/test_complete_set.py
@@ -48,7 +48,7 @@ contains_map = {
         "Int64_int_nan_series",
         "int_series_boolean",
     },
-    Count: {"np_uint32"},
+    Count: {"np_uint32", "pd_uint32"},
     Path: {"path_series_linux", "path_series_linux_missing", "path_series_windows"},
     URL: {"url_series", "url_nan_series", "url_none_series"},
     Float: {
@@ -179,6 +179,7 @@ inference_map = {
     "Int64_int_series": Integer,
     "Int64_int_nan_series": Integer,
     "np_uint32": Count,
+    "pd_uint32": Count,
     "int_range": Integer,
     "float_series": Float,
     "float_nan_series": Float,

--- a/tests/typesets/test_standard_set.py
+++ b/tests/typesets/test_standard_set.py
@@ -35,6 +35,8 @@ contains_map = {
         "int_range",
         "Int64_int_nan_series",
         "int_series_boolean",
+        "np_uint32",
+        "pd_uint32",
     },
     Float: {
         "float_series",
@@ -145,7 +147,6 @@ contains_map[Object] = {
 
 # Empty series
 contains_map[Generic] = {
-    "np_uint32",
     "empty",
     "empty_bool",
     "empty_float",
@@ -173,7 +174,8 @@ inference_map = {
     "int_nan_series": Integer,
     "Int64_int_series": Integer,
     "Int64_int_nan_series": Integer,
-    "np_uint32": Generic,
+    "np_uint32": Integer,
+    "pd_uint32": Integer,
     "int_range": Integer,
     "float_series": Float,
     "float_nan_series": Float,


### PR DESCRIPTION
This PR promotes the `Integer` type in the hierarchy with `Count` (a.k.a. natural numbers, positive integers) as child. Typesets containing both will Unsigned integer series are unaffected (e.g. CompleteSet). Typesets without `Count` will infer series with an unsigned integer dtype as `Integer` instead of `Generic`. 

Follow-up of https://github.com/dylan-profiler/visions/pull/108