### PR TITLE
TST: Remove python 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ jobs:
     - python: 3.6
     - python: 3.7
     - python: 3.8
-    - python: 3.9-dev
-  allow_failures:
-    - python: 3.9-dev
 
 env:
   - PANDAS="<1"


### PR DESCRIPTION
Running the test environment with python 3.9-dev takes a long time since some packages need to be built from scratch. The test barely adds value as it's allowed to fail. Removing speeds up the CI testing, while we can easily reintroduce the environment later.