### PR TITLE
TST: use full testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ dist: bionic
 language: python
 cache: pip
 
-jobs:
-  include:
-    - python: 3.6
-    - python: 3.7
-    - python: 3.8
+python:
+  - '3.6'
+  - '3.7'
+  - '3.8'
 
 env:
   - PANDAS="<1"


### PR DESCRIPTION
The current configuration runs tests for python 3.6 and pandas < 1 twice, instead of testing the combinations of python/pandas.