### PR TITLE
ENH: Extend the circular package plot to take any typeset

### DIFF
--- a/src/visions/visualisation/circular_packing.html
+++ b/src/visions/visualisation/circular_packing.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title></title>
+    <title>Typeset circular packing</title>
     <meta charset="utf-8">
     <style>
         .node {
@@ -49,8 +49,6 @@
         .size([diameter - margin, diameter - margin])
         .padding(30);
 
-    // d3.json("typesets/typeset_complete_base.json", function (error, root) {
-    //    if (error) throw error;
     // START-REPLACE
 	root = {"children": [{"name": "Boolean", "size": 1}, {"children": [{"name": "Ordinal", "size": 1}], "name": "Categorical"}, {"name": "Complex", "size": 1}, {"name": "DateTime", "size": 1}, {"name": "Float", "size": 1}, {"children": [{"name": "Count", "size": 1}], "name": "Integer"}, {"children": [{"name": "Date", "size": 1}, {"name": "EmailAddress", "size": 1}, {"name": "Geometry", "size": 1}, {"name": "IPAddress", "size": 1}, {"children": [{"children": [{"name": "Image", "size": 1}], "name": "File"}], "name": "Path"}, {"name": "String", "size": 1}, {"name": "Time", "size": 1}, {"name": "URL", "size": 1}, {"name": "UUID", "size": 1}], "name": "Object"}, {"name": "TimeDelta", "size": 1}], "name": "Generic"};
 	// END-REPLACE
@@ -100,7 +98,7 @@
             .style('font-size', function(d){
                 var parent = d3.select(this.parentNode);
                 var c = parent.select('circle');
-                return Math.round(8 + 0.75 * c.attr('r') / 10).toString() + 'px';
+                return Math.round(8 + Math.log10(1000 * c.attr('r'))).toString() + 'px';
             })
           .text(function(d) {
               return d.data.name;

--- a/src/visions/visualisation/plot_circular_packing.py
+++ b/src/visions/visualisation/plot_circular_packing.py
@@ -1,6 +1,7 @@
 import json
 import re
 from pathlib import Path
+from itertools import chain
 
 import networkx as nx
 
@@ -16,16 +17,12 @@ def update(data):
     return data
 
 
-def write_json(data):
-    with Path("typesets/typeset_complete_base.json").open("w") as f:
-        json.dump(data, f)
-
-
-def write_html(data):
+def write_html(data, output_file):
     jdata = json.dumps(data)
     string = f"\n\troot = {jdata};\n\t"
 
-    file_name = Path("circular_packing.html")
+    file_name = Path(__file__).parent / "circular_packing.html"
+    out_file = Path(output_file)
     fc = file_name.read_text()
     fc = re.sub(
         r"// START-REPLACE(.*)// END-REPLACE",
@@ -33,13 +30,11 @@ def write_html(data):
         fc,
         flags=re.MULTILINE | re.DOTALL,
     )
-    file_name.write_text(fc)
+    out_file.write_text(fc)
 
 
 def to_json_tree_sorted(G, root):
     # json_graph.tree_data with sorting
-    from itertools import chain
-
     def add_children(n, G):
         nbrs = G[n]
         if len(nbrs) == 0:
@@ -60,17 +55,15 @@ def to_json_tree_sorted(G, root):
     return data
 
 
-def write_circular_packing_files() -> None:
-    typeset = CompleteSet()
+def plot_graph_circular_packing(typeset, output_file) -> None:
     graph = typeset.base_graph.copy()
     nx.relabel_nodes(graph, {n: str(n) for n in graph.nodes}, copy=False)
 
-    data = to_json_tree_sorted(graph, root="Generic")
+    data = to_json_tree_sorted(graph, root=str(typeset.root_node))
     data = update(data)
-
-    write_json(data)
-    write_html(data)
+    write_html(data, output_file)
 
 
 if __name__ == "__main__":
-    write_circular_packing_files()
+    complete_set = CompleteSet()
+    plot_graph_circular_packing(complete_set, "circular_packing.html")

--- a/src/visions/visualisation/plot_typesets.py
+++ b/src/visions/visualisation/plot_typesets.py
@@ -24,6 +24,10 @@ def generate_typeset_plots() -> None:
         tsc.output_graph(typesets_dir / f"{name}.svg")
         tsc.output_graph(typesets_dir / f"{name}_base.svg", base_only=True)
 
+        # Plot the graph (pdf)
+        tsc.output_graph(typesets_dir / f"{name}.pdf")
+        tsc.output_graph(typesets_dir / f"{name}_base.pdf", base_only=True)
+
         # Plot the graph (png)
         tsc.output_graph(typesets_dir / f"{name}.png", dpi=150)
 


### PR DESCRIPTION
- Extend the circular package plot to take any typeset
- Scaling of font-size on zoom improved
- Generate PDF plots for default typesets