### PR TITLE
Add official OSI name in the license metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     version=__version__,
     url="https://github.com/dylan-profiler/visions",
     description="Visions",
+    license="BSD License",
     author="Dylan Profiler",
     author_email="visions@ictopzee.nl",
     package_data={"vision": ["py.typed"]},


### PR DESCRIPTION
This makes it easier for automatic license checkers to verify the license of this package.