### PR TITLE
prevent numpy warnings

### DIFF
--- a/src/visions/backends/numpy/sequences.py
+++ b/src/visions/backends/numpy/sequences.py
@@ -35,7 +35,7 @@ def get_sequences() -> Dict[str, Sequence]:
             "In the hot New Jersey night",
             np.nan,
         ],
-        "float_series3": np.array([1.2, 2, 3, 4], dtype=np.float),
+        "float_series3": np.array([1.2, 2, 3, 4], dtype=np.float64),
         "np_uint32": np.array([1, 2, 3, 4], dtype=np.uint32),
         "string_np_unicode_series": np.array(["upper", "hall"], dtype=np.unicode_),
         "complex_series": [np.complex128(0, 0), np.complex128(1, 2), np.complex128(3, -1)],

--- a/src/visions/backends/numpy/sequences.py
+++ b/src/visions/backends/numpy/sequences.py
@@ -39,7 +39,7 @@ def get_sequences() -> Dict[str, Sequence]:
         "np_uint32": np.array([1, 2, 3, 4], dtype=np.uint32),
         "string_np_unicode_series": np.array(["upper", "hall"], dtype=np.unicode_),
         "complex_series": [np.complex128(0, 0), np.complex128(1, 2), np.complex128(3, -1)],
-        "bool_series3": np.array([1, 0, 0, 1], dtype=np.bool),
+        "bool_series3": np.array([1, 0, 0, 1], dtype=np.bool_),
         "complex_series_nan": [
             np.complex128(0, 0),
             np.complex128(1, 2),

--- a/src/visions/backends/numpy/sequences.py
+++ b/src/visions/backends/numpy/sequences.py
@@ -7,10 +7,10 @@ import numpy as np
 def get_sequences() -> Dict[str, Sequence]:
     sequences = {
         "complex_series_float": [
-            np.complex(0, 0),
-            np.complex(1, 0),
-            np.complex(3, 0),
-            np.complex(-1, 0),
+            np.complex128(0, 0),
+            np.complex128(1, 0),
+            np.complex128(3, 0),
+            np.complex128(-1, 0),
         ],
         "url_nan_series": [
             urlparse("http://www.cwi.nl:80/%7Eguido/Python.html"),
@@ -38,18 +38,18 @@ def get_sequences() -> Dict[str, Sequence]:
         "float_series3": np.array([1.2, 2, 3, 4], dtype=np.float),
         "np_uint32": np.array([1, 2, 3, 4], dtype=np.uint32),
         "string_np_unicode_series": np.array(["upper", "hall"], dtype=np.unicode_),
-        "complex_series": [np.complex(0, 0), np.complex(1, 2), np.complex(3, -1)],
+        "complex_series": [np.complex128(0, 0), np.complex128(1, 2), np.complex128(3, -1)],
         "bool_series3": np.array([1, 0, 0, 1], dtype=np.bool),
         "complex_series_nan": [
-            np.complex(0, 0),
-            np.complex(1, 2),
-            np.complex(3, -1),
-            np.complex(np.nan, np.nan),
+            np.complex128(0, 0),
+            np.complex128(1, 2),
+            np.complex128(3, -1),
+            np.complex128(np.nan, np.nan),
         ],
         "complex_series_nan_2": [
-            np.complex(0, 0),
-            np.complex(1, 2),
-            np.complex(3, -1),
+            np.complex128(0, 0),
+            np.complex128(1, 2),
+            np.complex128(3, -1),
             np.nan,
         ],
         "complex_series_py_nan": [

--- a/src/visions/backends/pandas/sequences.py
+++ b/src/visions/backends/pandas/sequences.py
@@ -111,7 +111,7 @@ def get_sequences() -> Dict[str, Iterable]:
         "empty_int64": pd.Series([], dtype="Int64"),
         "empty_object": pd.Series([], dtype="object"),
         "empty_bool": pd.Series([], dtype=bool),
-        "float_series4": pd.Series([1, 2, 3.05, 4], dtype=np.float),
+        "float_series4": pd.Series([1, 2, 3.05, 4], dtype=np.float64),
         # Null Sequences
         "all_null_none": pd.Series([None, None]),
         "all_null_nan": pd.Series([np.nan, np.nan]),


### PR DESCRIPTION
>  DeprecationWarning: `np.complex` is a deprecated alias for the builtin `comp
lex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.

>  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    np.complex(3, -1),

---

>  DeprecationWarning: `np.float` is a deprecated alias for the builtin `floa
t`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    "float_series4": pd.Series([1, 2, 3.05, 4], dtype=np.float),
---

> DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`.
To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    "bool_series3": np.array([1, 0, 0, 1], dtype=np.bool),
