### PR TITLE
fix to email address and URL

### DIFF
--- a/src/visions/backends/python/types/email_address.py
+++ b/src/visions/backends/python/types/email_address.py
@@ -14,7 +14,7 @@ def string_is_email(sequence: Sequence, state: dict) -> bool:
         return False
 
 
-@EmailAddress.register_relationship(String, Sequence)
+@EmailAddress.register_transformer(String, Sequence)
 def string_to_email(sequence: Sequence, state: dict) -> Sequence:
     return tuple(map(_to_email, sequence))
 

--- a/src/visions/backends/python/types/url.py
+++ b/src/visions/backends/python/types/url.py
@@ -7,7 +7,7 @@ from visions.types.url import URL
 
 @URL.contains_op.register
 def url_contains(sequence: Sequence, state: dict) -> bool:
-    return all(isinstance(sequence, ParseResult) for value in sequence)
+    return all(isinstance(value, ParseResult) for value in sequence)
 
 
 @URL.register_transformer(String, Sequence)
@@ -18,7 +18,6 @@ def string_to_url(sequence: Sequence, state: dict) -> Sequence:
 @URL.register_relationship(String, Sequence)
 def string_is_url(sequence: Sequence, state: dict) -> bool:
     try:
-        _ = all(isinstance(urlparse(value), ParseResult) for value in sequence)
-        return True
+        return all(x.netloc and x.scheme for x in string_to_url(sequence, {}))
     except (ValueError, TypeError, AttributeError):
         return False


### PR DESCRIPTION
The `CompleteSet` of types was never tested for the standard python implementation and there appear to be a few regressions. This PR includes fixes for two:

* `EmailAddress` had two relationships registered rather than a relationship and and a transformer
* URL `contains_op` had a typo
* URL `relationship` wasn't correctly checking for scheme and netloc.

I don't have time right now to standup a full test suite for the CompleteSet @sbrugman, do you feel okay getting this in as a quick fix? 