### PR TITLE
Remove tangled_up_in_unicode dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ numpy
 pandas>=0.25.3
 attrs>=19.3.0
 networkx>=2.4
-tangled_up_in_unicode>=0.0.4
 multimethod>=1.4


### PR DESCRIPTION
It's not required since May 2021 (4ce2507473ae59b3078447f2655682a9b5681588)

Refs https://github.com/dylan-profiler/tangled-up-in-unicode/issues/10