### PR TITLE
Release 0.8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,19 @@ jobs:
     - name: Install GraphViz
       run: sudo apt-get install graphviz
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Configurating Git
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.8
+        python-version: "3.13"
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       name: Cache pip dependencies
       with:
         path: ~/.cache/pip

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
       name: Checkout repo
     
     - name: Set up Python 3.12
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.12
-    
-    - uses: actions/cache@v1
+        python-version: "3.12"
+
+    - uses: actions/cache@v4
       name: Cache pip dependencies
       with:
         path: ~/.cache/pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,26 +7,40 @@ on:
     branches: [ master, develop ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.14"
+    - name: Install lint dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pre-commit
+    - name: Lint with pre-commit
+      run: |
+        pre-commit run --all-files
+
   test:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python: [ 3.9, "3.10", 3.11, 3.12, 3.13 ]
+        python: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
     runs-on: ${{ matrix.os }}
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e .[testing]
-    - name: Lint with pre-commit
-      run: |
-        pre-commit run --all-files
     - name: Test with pytest
       run: |
         pytest -p no:spark -m "not spark_test"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.21.1
     hooks:
     -   id: pyupgrade
-        args: ['--py36-plus','--exit-zero-even-if-changed']
+        args: ['--py39-plus','--exit-zero-even-if-changed']
 -   repo: https://github.com/pycqa/isort
 
     rev: 5.13.2

--- a/examples/data_analysis/categorical.py
+++ b/examples/data_analysis/categorical.py
@@ -1,4 +1,5 @@
-from typing import List, Sequence
+from collections.abc import Sequence
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -23,7 +24,7 @@ def to_category(series: pd.Series) -> pd.Series:
         )
 
 
-def _get_relations(cls) -> List[TypeRelation]:
+def _get_relations(cls) -> list[TypeRelation]:
     from visions.types import Generic
 
     relations = [

--- a/examples/ml_problem_example.py
+++ b/examples/ml_problem_example.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,18 +8,19 @@ name = "visions"
 dynamic = ["version"]
 description = "Visions"
 readme = "README.md"
-license = { text = "BSD License" }
+license = "BSD-4-Clause"
+license-files = ["LICENSE"]
 authors = [
     { name = "Dylan Profiler", email = "visions@ictopzee.nl" }
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
-    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [

--- a/src/visions/__init__.py
+++ b/src/visions/__init__.py
@@ -12,4 +12,4 @@ from visions.functional import (
 from visions.types import *
 from visions.typesets import *
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/src/visions/backends/numpy/array_utils.py
+++ b/src/visions/backends/numpy/array_utils.py
@@ -1,5 +1,6 @@
 import functools
-from typing import Callable, Sequence, Tuple, TypeVar, Union
+from collections.abc import Sequence
+from typing import Callable, Tuple, TypeVar, Union
 
 import numpy as np
 
@@ -39,7 +40,7 @@ def array_not_empty(fn: Callable[..., bool]) -> Callable[..., bool]:
     return inner
 
 
-def _base_all_type(array: np.ndarray, dtypes: Union[type, Tuple[type, ...]]) -> bool:
+def _base_all_type(array: np.ndarray, dtypes: Union[type, tuple[type, ...]]) -> bool:
     return all(isinstance(v, dtypes) for v in array)
 
 
@@ -48,7 +49,7 @@ if has_numba:
     # There are alternative implementations with forceobj=True which work in all cases
     # including the use of isinstance, but in those cases worst case performance can be substantially worse
     # than the default python implementation.
-    def all_type_numba(dtype: Union[Tuple, T]):
+    def all_type_numba(dtype: Union[tuple, T]):
         @nb.jit(nopython=True)
         def inner(array: np.ndarray) -> bool:
             for i in nb.prange(array.size):
@@ -58,10 +59,10 @@ if has_numba:
 
         return inner
 
-    def all_type(array: np.ndarray, dtypes: Union[type, Tuple[type, ...]]) -> bool:
+    def all_type(array: np.ndarray, dtypes: Union[type, tuple[type, ...]]) -> bool:
         return _base_all_type(array, dtypes)
 
 else:
 
-    def all_type(array: np.ndarray, dtypes: Union[type, Tuple[type, ...]]) -> bool:
+    def all_type(array: np.ndarray, dtypes: Union[type, tuple[type, ...]]) -> bool:
         return _base_all_type(array, dtypes)

--- a/src/visions/backends/numpy/sequences.py
+++ b/src/visions/backends/numpy/sequences.py
@@ -1,10 +1,11 @@
-from typing import Dict, Sequence
+from collections.abc import Sequence
+from typing import Dict
 from urllib.parse import urlparse
 
 import numpy as np
 
 
-def get_sequences() -> Dict[str, Sequence]:
+def get_sequences() -> dict[str, Sequence]:
     sequences = {
         "complex_series_float": [
             complex(0, 0),

--- a/src/visions/backends/numpy/test_utils.py
+++ b/src/visions/backends/numpy/test_utils.py
@@ -12,7 +12,7 @@ from visions.backends.numpy.array_utils import array_handle_nulls
 
 def option_coercion_evaluator(
     fn: Callable[[np.ndarray], np.ndarray],
-    extra_errors: Optional[List[Type[Exception]]] = None,
+    extra_errors: Optional[list[type[Exception]]] = None,
 ) -> Callable[[np.ndarray], Optional[np.ndarray]]:
     """A coercion test evaluator
     Evaluates a coercion function and optionally returns the coerced array.
@@ -39,7 +39,7 @@ def option_coercion_evaluator(
 
 def coercion_test(
     fn: Callable[[np.ndarray], np.ndarray],
-    extra_errors: Optional[List[Type[Exception]]] = None,
+    extra_errors: Optional[list[type[Exception]]] = None,
 ) -> Callable[[np.ndarray], bool]:
     """A coercion test generator
     Creates a coercion test based on a provided coercion function.
@@ -62,7 +62,7 @@ def coercion_test(
 
 def coercion_true_test(
     fn: Callable[[np.ndarray], np.ndarray],
-    extra_errors: Optional[List[Type[Exception]]] = None,
+    extra_errors: Optional[list[type[Exception]]] = None,
 ) -> Callable[[np.ndarray], bool]:
     """A coercion equality test generator
     Creates a coercion test based on a provided coercion function which also enforces
@@ -108,7 +108,7 @@ def coercion_equality_test(
     return f
 
 
-def coercion_single_map_test(mapping: List[Dict]) -> Callable[[np.ndarray, Dict], bool]:
+def coercion_single_map_test(mapping: list[dict]) -> Callable[[np.ndarray, dict], bool]:
     @array_handle_nulls
     def f(array: np.ndarray, state: dict = {}) -> bool:
         return any(
@@ -118,7 +118,7 @@ def coercion_single_map_test(mapping: List[Dict]) -> Callable[[np.ndarray, Dict]
     return f
 
 
-def coercion_multi_map_test(mapping: Dict) -> Callable[[np.ndarray, Dict], bool]:
+def coercion_multi_map_test(mapping: dict) -> Callable[[np.ndarray, dict], bool]:
     @array_handle_nulls
     def f(array: np.ndarray, state: dict = {}) -> bool:
         return np.isin(array, list(mapping.keys())).all()
@@ -127,8 +127,8 @@ def coercion_multi_map_test(mapping: Dict) -> Callable[[np.ndarray, Dict], bool]
 
 
 def coercion_map_test(
-    mapping: Union[List[Dict], Dict],
-) -> Callable[[np.ndarray, Dict], bool]:
+    mapping: Union[list[dict], dict],
+) -> Callable[[np.ndarray, dict], bool]:
     """Create a testing function for a single mapping or a list of mappings.
     Args:
         mapping: A dict with a mapping or a list of dicts
@@ -154,7 +154,7 @@ def coercion_map_test(
 
 
 def coercion_map(
-    mapping: Union[List[Dict], Dict],
+    mapping: Union[list[dict], dict],
 ) -> Callable[[np.ndarray], np.ndarray]:
     """Maps a array given a mapping
     Args:

--- a/src/visions/backends/numpy/types/float.py
+++ b/src/visions/backends/numpy/types/float.py
@@ -16,7 +16,7 @@ def test_string_leading_zeros(array: np.ndarray, coerced_array: np.ndarray):
 @array_handle_nulls
 def string_is_float(array: np.ndarray, state: dict) -> bool:
     coerced_array = test_utils.option_coercion_evaluator(
-        lambda s: s.astype(np.floating)
+        lambda s: s.astype(np.float64)
     )(array)
 
     return (
@@ -28,7 +28,7 @@ def string_is_float(array: np.ndarray, state: dict) -> bool:
 
 @Float.register_transformer(String, np.ndarray)
 def string_to_float(array: np.array, state: dict) -> np.ndarray:
-    return array.astype(np.floating)
+    return array.astype(np.float64)
 
 
 @Float.register_relationship(Complex, np.ndarray)
@@ -38,7 +38,7 @@ def complex_is_float(array: np.array, state: dict) -> bool:
 
 @Float.register_transformer(Complex, np.ndarray)
 def complex_to_float(array: np.array, state: dict) -> np.ndarray:
-    return suppress_warnings(lambda s: s.astype(np.floating))(array)
+    return suppress_warnings(lambda s: s.astype(np.float64))(array)
 
 
 @Float.contains_op.register

--- a/src/visions/backends/pandas/sequences.py
+++ b/src/visions/backends/pandas/sequences.py
@@ -1,5 +1,6 @@
 import datetime
-from typing import Dict, Iterable
+from collections.abc import Iterable
+from typing import Dict
 
 import numpy as np
 import pandas as pd
@@ -8,7 +9,7 @@ from visions.backends.pandas.test_utils import pandas_version
 from visions.backends.pandas.types.boolean import hasnan_bool_name
 
 
-def get_sequences() -> Dict[str, Iterable]:
+def get_sequences() -> dict[str, Iterable]:
     sequences = {
         "float_series6": pd.Series([np.nan, 1.1], dtype=np.single),
         "bool_series2": pd.Series([True, False, False, True], dtype=bool),

--- a/src/visions/backends/pandas/series_utils.py
+++ b/src/visions/backends/pandas/series_utils.py
@@ -3,6 +3,19 @@ from typing import Callable
 
 import pandas as pd
 
+_PANDAS_VERSION = tuple(map(int, pd.__version__.split(".")[:2]))
+
+if _PANDAS_VERSION >= (0, 24):
+
+    def pandas_is_categorical(series: pd.Series) -> bool:
+        return isinstance(series.dtype, pd.CategoricalDtype)
+
+else:
+    from pandas.api import types as pdt
+
+    def pandas_is_categorical(series: pd.Series) -> bool:
+        return pdt.is_categorical_dtype(series)
+
 
 # For future reference: get the dtype from the subtype when the series is sparse
 def series_handle_sparse_dtype(fn: Callable[..., bool]) -> Callable[..., bool]:
@@ -42,7 +55,7 @@ def series_not_sparse(fn: Callable[..., bool]) -> Callable[..., bool]:
 
     @functools.wraps(fn)
     def inner(series: pd.Series, *args, **kwargs) -> bool:
-        if isinstance(series, pd.SparseDtype):
+        if isinstance(series.dtype, pd.SparseDtype):
             return False
         return fn(series, *args, **kwargs)
 

--- a/src/visions/backends/pandas/test_utils.py
+++ b/src/visions/backends/pandas/test_utils.py
@@ -15,7 +15,7 @@ pandas_na_value = pd.NA if hasattr(pd, "NA") else None
 
 def option_coercion_evaluator(
     fn: Callable[[pd.Series], pd.Series],
-    extra_errors: Optional[List[Type[Exception]]] = None,
+    extra_errors: Optional[list[type[Exception]]] = None,
 ) -> Callable[[pd.Series], Optional[pd.Series]]:
     """A coercion test evaluator
     Evaluates a coercion function and optionally returns the coerced series.
@@ -42,7 +42,7 @@ def option_coercion_evaluator(
 
 def coercion_test(
     fn: Callable[[pd.Series], pd.Series],
-    extra_errors: Optional[List[Type[Exception]]] = None,
+    extra_errors: Optional[list[type[Exception]]] = None,
 ) -> Callable[[pd.Series], bool]:
     """A coercion test generator
     Creates a coercion test based on a provided coercion function.
@@ -65,7 +65,7 @@ def coercion_test(
 
 def coercion_true_test(
     fn: Callable[[pd.Series], pd.Series],
-    extra_errors: Optional[List[Type[Exception]]] = None,
+    extra_errors: Optional[list[type[Exception]]] = None,
 ) -> Callable[[pd.Series], bool]:
     """A coercion equality test generator
     Creates a coercion test based on a provided coercion function which also enforces
@@ -111,7 +111,7 @@ def coercion_equality_test(
     return f
 
 
-def coercion_single_map_test(mapping: List[Dict]) -> Callable[[pd.Series, Dict], bool]:
+def coercion_single_map_test(mapping: list[dict]) -> Callable[[pd.Series, dict], bool]:
     @series_handle_nulls
     def f(series: pd.Series, state: dict = {}) -> bool:
         return any(series.isin(list(single_map.keys())).all() for single_map in mapping)
@@ -119,7 +119,7 @@ def coercion_single_map_test(mapping: List[Dict]) -> Callable[[pd.Series, Dict],
     return f
 
 
-def coercion_multi_map_test(mapping: Dict) -> Callable[[pd.Series, Dict], bool]:
+def coercion_multi_map_test(mapping: dict) -> Callable[[pd.Series, dict], bool]:
     @series_handle_nulls
     def f(series: pd.Series, state: dict = {}) -> bool:
         return series.isin(list(mapping.keys())).all()
@@ -128,8 +128,8 @@ def coercion_multi_map_test(mapping: Dict) -> Callable[[pd.Series, Dict], bool]:
 
 
 def coercion_map_test(
-    mapping: Union[List[Dict], Dict],
-) -> Callable[[pd.Series, Dict], bool]:
+    mapping: Union[list[dict], dict],
+) -> Callable[[pd.Series, dict], bool]:
     """Create a testing function for a single mapping or a list of mappings.
     Args:
         mapping: A dict with a mapping or a list of dicts
@@ -154,7 +154,7 @@ def coercion_map_test(
     return f
 
 
-def coercion_map(mapping: Union[List[Dict], Dict]) -> Callable[[pd.Series], pd.Series]:
+def coercion_map(mapping: Union[list[dict], dict]) -> Callable[[pd.Series], pd.Series]:
     """Maps a series given a mapping
     Args:
         mapping: a dict to map, or a list of dicts.

--- a/src/visions/backends/pandas/traversal.py
+++ b/src/visions/backends/pandas/traversal.py
@@ -6,27 +6,27 @@ import pandas as pd
 from visions.types.type import VisionsBaseType
 from visions.typesets.typeset import traverse_graph, traverse_graph_with_series
 
-T = Type[VisionsBaseType]
+T = type[VisionsBaseType]
 
 
 @traverse_graph.register(pd.Series)
 def _traverse_graph_series(
     series: pd.Series, root_node: T, graph: nx.DiGraph
-) -> Tuple[pd.Series, List[T], dict]:
+) -> tuple[pd.Series, list[T], dict]:
     return traverse_graph_with_series(root_node, series, graph)
 
 
 @traverse_graph.register(pd.DataFrame)
 def _traverse_graph_dataframe(
     df: pd.DataFrame, root_node: T, graph: nx.DiGraph
-) -> Tuple[pd.DataFrame, Dict[str, List[T]], Dict[str, dict]]:
+) -> tuple[pd.DataFrame, dict[str, list[T]], dict[str, dict]]:
     inferred_values = {
         col: traverse_graph(df[col], root_node, graph) for col in df.columns
     }
 
     inferred_series = {}
-    inferred_paths: Dict[str, List[T]] = {}
-    inferred_states: Dict[str, dict] = {}
+    inferred_paths: dict[str, list[T]] = {}
+    inferred_states: dict[str, dict] = {}
     for col, (inf_series, inf_path, inf_state) in inferred_values.items():
         assert isinstance(inf_path, list)  # Placate the MyPy Gods
 

--- a/src/visions/backends/pandas/types/boolean.py
+++ b/src/visions/backends/pandas/types/boolean.py
@@ -4,9 +4,9 @@ import pandas as pd
 import pandas.api.types as pdt
 
 from visions.backends.pandas.series_utils import (
+    pandas_is_categorical,
     series_handle_nulls,
     series_not_empty,
-    series_not_sparse,
 )
 from visions.backends.pandas.test_utils import (
     coercion_map,
@@ -56,8 +56,7 @@ def string_to_boolean(series: pd.Series, state: dict) -> pd.Series:
 
 
 @Boolean.contains_op.register
-@series_not_sparse
 @series_handle_nulls
 @series_not_empty
 def boolean_contains(series: pd.Series, state: dict) -> bool:
-    return pdt.is_bool_dtype(series) and not pdt.is_categorical_dtype(series)
+    return pdt.is_bool_dtype(series) and not pandas_is_categorical(series)

--- a/src/visions/backends/pandas/types/categorical.py
+++ b/src/visions/backends/pandas/types/categorical.py
@@ -1,7 +1,10 @@
 import pandas as pd
-from pandas.api import types as pdt
 
-from visions.backends.pandas.series_utils import series_not_empty, series_not_sparse
+from visions.backends.pandas.series_utils import (
+    pandas_is_categorical,
+    series_not_empty,
+    series_not_sparse,
+)
 from visions.types.categorical import Categorical
 
 
@@ -9,4 +12,4 @@ from visions.types.categorical import Categorical
 @series_not_sparse
 @series_not_empty
 def categorical_contains(series: pd.Series, state: dict) -> bool:
-    return pdt.is_categorical_dtype(series)
+    return pandas_is_categorical(series)

--- a/src/visions/backends/pandas/types/complex.py
+++ b/src/visions/backends/pandas/types/complex.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pandas.api import types as pdt
 
 from visions.backends.pandas import test_utils
-from visions.backends.pandas.series_utils import series_not_empty, series_not_sparse
+from visions.backends.pandas.series_utils import series_not_empty
 from visions.backends.shared.parallelization_engines import pandas_apply
 from visions.types.complex import Complex
 from visions.types.string import String
@@ -48,7 +48,6 @@ def string_to_complex(series: pd.Series, state: dict) -> pd.Series:
 
 
 @Complex.contains_op.register
-@series_not_sparse
 @series_not_empty
 def complex_contains(series: pd.Series, state: dict) -> bool:
     return pdt.is_complex_dtype(series)

--- a/src/visions/backends/pandas/types/date_time.py
+++ b/src/visions/backends/pandas/types/date_time.py
@@ -9,14 +9,18 @@ from visions.backends.pandas.series_utils import (
 )
 from visions.types import DateTime, String
 
+_PANDAS_VERSION = tuple(map(int, pd.__version__.split(".")[:2]))
 
-def pandas_infer_datetime(series: pd.Series, state: dict) -> pd.Series:
-    try:
+
+if _PANDAS_VERSION >= (2, 0):
+
+    def pandas_infer_datetime(series: pd.Series, state: dict) -> pd.Series:
+        return pd.to_datetime(series, format="mixed")
+
+else:
+
+    def pandas_infer_datetime(series: pd.Series, state: dict) -> pd.Series:
         return pd.to_datetime(series)
-    except Exception:
-        pass
-
-    return pd.to_datetime(series, format="mixed")
 
 
 @DateTime.register_relationship(String, pd.Series)

--- a/src/visions/backends/pandas/types/float.py
+++ b/src/visions/backends/pandas/types/float.py
@@ -59,7 +59,6 @@ def complex_to_float(series: pd.Series, state: dict) -> pd.Series:
 
 
 @Float.contains_op.register
-@series_not_sparse
 @series_handle_nulls
 @series_not_empty
 def float_contains(series: pd.Series, state: dict) -> bool:

--- a/src/visions/backends/pandas/types/geometry.py
+++ b/src/visions/backends/pandas/types/geometry.py
@@ -1,5 +1,5 @@
 import os
-import sys
+from contextlib import redirect_stderr
 
 import pandas as pd
 
@@ -7,29 +7,31 @@ from visions.backends.pandas.series_utils import series_handle_nulls, series_not
 from visions.types.geometry import Geometry
 from visions.types.string import String
 
+try:
+    from shapely.errors import ShapelyError
+except ImportError:
+    from shapely.errors import WKTReadingError as ShapelyError
+
 
 # TODO: Evaluate https://jorisvandenbossche.github.io/blog/2019/08/13/geopandas-extension-array-refactor/
 @Geometry.register_relationship(String, pd.Series)
 def string_is_geometry(sequence: pd.Series, state: dict) -> bool:
     """Shapely logs failures at a silly severity, just trying to suppress it's output on failures."""
     from shapely import wkt
-    from shapely.errors import WKTReadingError
 
     # only way to get rid of sys output when wkt.loads hits a bad value
     # TODO: use coercion wrapper for this
-    sys.stderr = open(os.devnull, "w")
-    try:
-        result = all(wkt.loads(value) for value in sequence)
-    except (
-        WKTReadingError,
-        AttributeError,
-        UnicodeEncodeError,
-        TypeError,
-        UnicodeDecodeError,
-    ):
-        result = False
-    finally:
-        sys.stderr = sys.__stderr__
+    with open(os.devnull, "w") as devnull, redirect_stderr(devnull):
+        try:
+            result = all(wkt.loads(value) for value in sequence)
+        except (
+            ShapelyError,
+            AttributeError,
+            UnicodeEncodeError,
+            TypeError,
+            UnicodeDecodeError,
+        ):
+            result = False
     return result
 
 

--- a/src/visions/backends/pandas/types/integer.py
+++ b/src/visions/backends/pandas/types/integer.py
@@ -2,11 +2,7 @@ import numpy as np
 import pandas as pd
 from pandas.api import types as pdt
 
-from visions.backends.pandas.series_utils import (
-    series_handle_nulls,
-    series_not_empty,
-    series_not_sparse,
-)
+from visions.backends.pandas.series_utils import series_handle_nulls, series_not_empty
 from visions.types.float import Float
 from visions.types.integer import Integer
 
@@ -32,7 +28,6 @@ def float_to_integer(series: pd.Series, state: dict) -> pd.Series:
 
 
 @Integer.contains_op.register
-@series_not_sparse
 @series_not_empty
 def integer_contains(series: pd.Series, state: dict) -> bool:
     return pdt.is_integer_dtype(series)

--- a/src/visions/backends/pandas/types/object.py
+++ b/src/visions/backends/pandas/types/object.py
@@ -2,9 +2,9 @@ import pandas as pd
 from pandas.api import types as pdt
 
 from visions.backends.pandas.series_utils import (
+    pandas_is_categorical,
     series_handle_nulls,
     series_not_empty,
-    series_not_sparse,
 )
 from visions.types.object import Object
 
@@ -12,7 +12,6 @@ pandas_has_string_dtype_flag = hasattr(pdt, "is_string_dtype")
 
 
 @Object.contains_op.register
-@series_not_sparse
 @series_handle_nulls
 @series_not_empty
 def object_contains(series: pd.Series, state: dict) -> bool:
@@ -20,7 +19,7 @@ def object_contains(series: pd.Series, state: dict) -> bool:
     if is_object:
         ret = True
     elif pandas_has_string_dtype_flag:
-        ret = pdt.is_string_dtype(series) and not pdt.is_categorical_dtype(series)
+        ret = pdt.is_string_dtype(series) and not pandas_is_categorical(series)
     else:
         ret = False
     return ret

--- a/src/visions/backends/pandas/types/ordinal.py
+++ b/src/visions/backends/pandas/types/ordinal.py
@@ -1,7 +1,6 @@
 import pandas as pd
-from pandas.api import types as pdt
 
-from visions.backends.pandas.series_utils import series_not_empty
+from visions.backends.pandas.series_utils import pandas_is_categorical, series_not_empty
 from visions.types.ordinal import Ordinal
 
 # @Ordinal.register_transformer(Categorical, pd.Series)
@@ -14,4 +13,4 @@ from visions.types.ordinal import Ordinal
 @Ordinal.contains_op.register
 @series_not_empty
 def ordinal_contains(series: pd.Series, state: dict) -> bool:
-    return pdt.is_categorical_dtype(series) and series.cat.ordered
+    return pandas_is_categorical(series) and series.cat.ordered

--- a/src/visions/backends/pandas/types/string.py
+++ b/src/visions/backends/pandas/types/string.py
@@ -2,6 +2,7 @@ import pandas as pd
 from pandas.api import types as pdt
 
 from visions.backends.pandas.series_utils import (
+    pandas_is_categorical,
     series_handle_nulls,
     series_not_empty,
     series_not_sparse,
@@ -13,19 +14,34 @@ pandas_has_string_dtype_flag = hasattr(pdt, "is_string_dtype")
 
 @series_handle_nulls
 def _is_string(series: pd.Series, state: dict):
+    if isinstance(series.dtype, pd.SparseDtype):
+        return pandas_sparse_is_string(series.array)
+
     if not all(isinstance(v, str) for v in series.values[0:5]):
         return False
-    try:
-        return (series.astype(str).values == series.values).all()
-    except (TypeError, ValueError):
+
+    return (
+        series.astype(str).to_numpy(dtype=object) == series.to_numpy(dtype=object)
+    ).all()
+
+
+def pandas_sparse_is_string(array: pd.arrays.SparseArray) -> bool:
+    # Check if special values are not all strings
+    if pandas_has_string_dtype_flag and not pdt.is_string_dtype(array.sp_values):
         return False
+
+    # If every value is explicitly stored, fill_value is not semantic content
+    if len(array) == len(array.sp_values):
+        return True
+
+    # Otherwise omitted positions are fill_value, so it must be string or missing
+    return isinstance(array.fill_value, str) or pd.isna(array.fill_value)
 
 
 @String.contains_op.register
-@series_not_sparse
 @series_not_empty
 def string_contains(series: pd.Series, state: dict) -> bool:
-    if pdt.is_categorical_dtype(series):
+    if pandas_is_categorical(series):
         return False
     elif not pdt.is_object_dtype(series):
         return pandas_has_string_dtype_flag and pdt.is_string_dtype(series)

--- a/src/visions/backends/python/sequences.py
+++ b/src/visions/backends/python/sequences.py
@@ -1,15 +1,16 @@
 import datetime
 import os
 import uuid
+from collections.abc import Sequence
 from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import Dict, Sequence, cast
+from typing import Dict, cast
 from urllib.parse import urlparse
 
 from visions.types.email_address import FQDA
 
 
-def get_sequences() -> Dict[str, Sequence]:
+def get_sequences() -> dict[str, Sequence]:
     base_path = Path(__file__).parent.parent.parent.absolute()
 
     sequences = {
@@ -183,4 +184,4 @@ def get_sequences() -> Dict[str, Sequence]:
         "email_address_str": ["test@example.com", "info@example.eu"],
     }
     assert all(isinstance(v, Sequence) for v in sequences.values())
-    return cast(Dict[str, Sequence], sequences)
+    return cast(dict[str, Sequence], sequences)

--- a/src/visions/backends/python/series_utils.py
+++ b/src/visions/backends/python/series_utils.py
@@ -1,5 +1,6 @@
 import functools
-from typing import Callable, Sequence
+from collections.abc import Sequence
+from typing import Callable
 
 
 def sequence_not_empty(fn: Callable[..., bool]) -> Callable[..., bool]:

--- a/src/visions/backends/python/types/boolean.py
+++ b/src/visions/backends/python/types/boolean.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Sequence
+from collections.abc import Sequence
+from typing import Dict, List
 
 from visions.backends.python.series_utils import (
     sequence_handle_none,
@@ -7,7 +8,7 @@ from visions.backends.python.series_utils import (
 from visions.types import Boolean, Object, String
 
 
-def get_boolean_coercions(id: str) -> List[Dict]:
+def get_boolean_coercions(id: str) -> list[dict]:
     coercion_map = {
         "default": [{"true": True, "false": False}],
         "en": [

--- a/src/visions/backends/python/types/categorical.py
+++ b/src/visions/backends/python/types/categorical.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.types.categorical import Categorical
 

--- a/src/visions/backends/python/types/complex.py
+++ b/src/visions/backends/python/types/complex.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.backends.python.series_utils import sequence_not_empty
 from visions.backends.python.types.float import no_leading_zeros

--- a/src/visions/backends/python/types/count.py
+++ b/src/visions/backends/python/types/count.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.types.count import Count
 

--- a/src/visions/backends/python/types/date.py
+++ b/src/visions/backends/python/types/date.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from datetime import date, time
-from typing import Sequence
 
 from visions.types.date import Date
 from visions.types.date_time import DateTime

--- a/src/visions/backends/python/types/date_time.py
+++ b/src/visions/backends/python/types/date_time.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from datetime import datetime
-from typing import Sequence
 
 from visions.backends.python.series_utils import sequence_not_empty
 from visions.types.date_time import DateTime

--- a/src/visions/backends/python/types/email_address.py
+++ b/src/visions/backends/python/types/email_address.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.types.email_address import FQDA, EmailAddress, _to_email
 from visions.types.string import String

--- a/src/visions/backends/python/types/file.py
+++ b/src/visions/backends/python/types/file.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.types.file import File
 

--- a/src/visions/backends/python/types/float.py
+++ b/src/visions/backends/python/types/float.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.backends.python.series_utils import sequence_not_empty
 from visions.types.complex import Complex

--- a/src/visions/backends/python/types/geometry.py
+++ b/src/visions/backends/python/types/geometry.py
@@ -1,26 +1,28 @@
 import os
-import sys
-from typing import Sequence
+from collections.abc import Sequence
+from contextlib import redirect_stderr
 
 from visions.types.geometry import Geometry
 from visions.types.string import String
+
+try:
+    from shapely.errors import ShapelyError
+except ImportError:
+    from shapely.errors import WKTReadingError as ShapelyError
 
 
 @Geometry.register_relationship(String, Sequence)
 def string_is_geometry(sequence: Sequence, state: dict) -> bool:
     """Shapely logs failures at a silly severity, just trying to suppress it's output on failures."""
     from shapely import wkt
-    from shapely.errors import WKTReadingError
 
     # only way to get rid of sys output when wkt.loads hits a bad value
     # TODO: use coercion wrapper for this
-    sys.stderr = open(os.devnull, "w")
-    try:
-        result = all(wkt.loads(value) for value in sequence)
-    except (WKTReadingError, AttributeError, UnicodeEncodeError, TypeError):
-        result = False
-    finally:
-        sys.stderr = sys.__stderr__
+    with open(os.devnull, "w") as devnull, redirect_stderr(devnull):
+        try:
+            result = all(wkt.loads(value) for value in sequence)
+        except (ShapelyError, AttributeError, UnicodeEncodeError, TypeError):
+            result = False
     return result
 
 

--- a/src/visions/backends/python/types/image.py
+++ b/src/visions/backends/python/types/image.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.types.image import Image
 from visions.utils.images.image_utils import path_is_image

--- a/src/visions/backends/python/types/integer.py
+++ b/src/visions/backends/python/types/integer.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.backends.python.series_utils import sequence_not_empty
 from visions.types.float import Float

--- a/src/visions/backends/python/types/ip_address.py
+++ b/src/visions/backends/python/types/ip_address.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from ipaddress import _BaseAddress, ip_address
-from typing import Sequence
 
 from visions.types.ip_address import IPAddress
 from visions.types.string import String

--- a/src/visions/backends/python/types/numeric.py
+++ b/src/visions/backends/python/types/numeric.py
@@ -1,5 +1,5 @@
 import numbers
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.types.numeric import Numeric
 

--- a/src/visions/backends/python/types/object.py
+++ b/src/visions/backends/python/types/object.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.backends.python.series_utils import (
     sequence_handle_none,

--- a/src/visions/backends/python/types/ordinal.py
+++ b/src/visions/backends/python/types/ordinal.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.types.ordinal import Ordinal
 

--- a/src/visions/backends/python/types/path.py
+++ b/src/visions/backends/python/types/path.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.types.path import Path
 from visions.types.string import String

--- a/src/visions/backends/python/types/string.py
+++ b/src/visions/backends/python/types/string.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.backends.python.series_utils import (
     sequence_handle_none,

--- a/src/visions/backends/python/types/time.py
+++ b/src/visions/backends/python/types/time.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from datetime import time
-from typing import Sequence
 
 # from visions.types.date_time import DateTime
 from visions.types.time import Time

--- a/src/visions/backends/python/types/time_delta.py
+++ b/src/visions/backends/python/types/time_delta.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from datetime import timedelta
-from typing import Sequence
 
 from visions.backends.python.series_utils import sequence_not_empty
 from visions.types.time_delta import TimeDelta

--- a/src/visions/backends/python/types/url.py
+++ b/src/visions/backends/python/types/url.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 from urllib.parse import ParseResult, urlparse
 
 from visions.types.string import String

--- a/src/visions/backends/python/types/uuid.py
+++ b/src/visions/backends/python/types/uuid.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Sequence
+from collections.abc import Sequence
 
 from visions.types.string import String
 from visions.types.uuid import UUID

--- a/src/visions/backends/shared/parallelization_engines.py
+++ b/src/visions/backends/shared/parallelization_engines.py
@@ -54,13 +54,13 @@ _PANDAS_ENGINES = [PandasEngine, SwifterEngine]
 
 
 class EngineCollection:
-    def __init__(self, engines: List[Type[Engine]]):
+    def __init__(self, engines: list[type[Engine]]):
         self.engines = {engine.name: engine for engine in engines}
 
     def is_engine(self, name: str) -> bool:
         return name in self.engines
 
-    def get(self, name: str) -> Type[Engine]:
+    def get(self, name: str) -> type[Engine]:
         return self.engines[name]
 
 
@@ -68,10 +68,10 @@ class PandasApply:
     supported_engines = EngineCollection(
         [engine for engine in _PANDAS_ENGINES if hasattr(engine, "apply")]
     )
-    _engine: Type[Engine] = PandasEngine
+    _engine: type[Engine] = PandasEngine
 
     @property
-    def engine(self) -> Type[Engine]:
+    def engine(self) -> type[Engine]:
         return self._engine
 
     @engine.setter

--- a/src/visions/backends/spark/traversal.py
+++ b/src/visions/backends/spark/traversal.py
@@ -7,21 +7,21 @@ from pyspark.sql.dataframe import DataFrame
 from visions.types.type import VisionsBaseType
 from visions.typesets.typeset import traverse_graph, traverse_graph_with_series
 
-T = Type[VisionsBaseType]
+T = type[VisionsBaseType]
 
 
 @traverse_graph.register(DataFrame)
 def _traverse_graph_spark_dataframe(
     df: DataFrame, root_node: T, graph: nx.DiGraph
-) -> Tuple[DataFrame, Dict[str, List[T]], Dict[str, dict]]:
+) -> tuple[DataFrame, dict[str, list[T]], dict[str, dict]]:
     inferred_values = {
         col: traverse_graph_with_series(root_node, df.select(col), graph)
         for col in df.columns
     }
 
     inferred_series = {}
-    inferred_paths: Dict[str, List[T]] = {}
-    inferred_states: Dict[str, dict] = {}
+    inferred_paths: dict[str, list[T]] = {}
+    inferred_states: dict[str, dict] = {}
     for col, (inf_series, inf_path, inf_state) in inferred_values.items():
         assert isinstance(inf_path, list)  # Placate the MyPy Gods
 

--- a/src/visions/contrib/relations/relations_utils.py
+++ b/src/visions/contrib/relations/relations_utils.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 
 def values_are_consecutive(sequence: Sequence) -> bool:

--- a/src/visions/declarative.py
+++ b/src/visions/declarative.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, List, Optional, Sequence, Type, TypeVar, Union
+from collections.abc import Sequence
+from typing import Any, Callable, List, Optional, Type, TypeVar, Union
 
 from visions.relations import IdentityRelation, InferenceRelation
 from visions.types.type import VisionsBaseType
@@ -6,7 +7,7 @@ from visions.types.type import VisionsBaseType
 T = TypeVar("T")
 
 
-def process_relation(items: Union[dict, Type[VisionsBaseType]]) -> IdentityRelation:
+def process_relation(items: Union[dict, type[VisionsBaseType]]) -> IdentityRelation:
     if isinstance(items, dict):
         return IdentityRelation(**items)
     elif issubclass(items, VisionsBaseType):
@@ -19,9 +20,9 @@ def create_type(
     name: str,
     contains: Callable[[Any, dict], bool],
     identity: Optional[
-        Union[Type[VisionsBaseType], List[Union[dict, Type[VisionsBaseType]]], dict]
+        Union[type[VisionsBaseType], list[Union[dict, type[VisionsBaseType]]], dict]
     ] = None,
-    inference: Optional[Union[List[dict], dict]] = None,
+    inference: Optional[Union[list[dict], dict]] = None,
 ):
     def get_relations():
         if isinstance(identity, Sequence):

--- a/src/visions/functional.py
+++ b/src/visions/functional.py
@@ -1,11 +1,12 @@
-from typing import Dict, List, Sequence, Tuple, Type, Union
+from collections.abc import Sequence
+from typing import Dict, List, Tuple, Type, Union
 
 import pandas as pd
 
 from visions.types.type import VisionsBaseType
 from visions.typesets.typeset import VisionsTypeset
 
-T = Type[VisionsBaseType]
+T = type[VisionsBaseType]
 
 
 def cast_to_detected(data: Sequence, typeset: VisionsTypeset) -> Sequence:
@@ -36,7 +37,7 @@ def cast_to_inferred(data: Sequence, typeset: VisionsTypeset) -> Sequence:
     return typeset.cast_to_inferred(data)
 
 
-def infer_type(data: Sequence, typeset: VisionsTypeset) -> Union[Dict[str, T], T]:
+def infer_type(data: Sequence, typeset: VisionsTypeset) -> Union[dict[str, T], T]:
     """Infer the current types of each column in the DataFrame given the typeset.
 
     Args:
@@ -49,7 +50,7 @@ def infer_type(data: Sequence, typeset: VisionsTypeset) -> Union[Dict[str, T], T
     return typeset.infer_type(data)
 
 
-def detect_type(data: Sequence, typeset: VisionsTypeset) -> Union[Dict[str, T], T]:
+def detect_type(data: Sequence, typeset: VisionsTypeset) -> Union[dict[str, T], T]:
     """Detect the type in the base graph
 
     Args:
@@ -64,7 +65,7 @@ def detect_type(data: Sequence, typeset: VisionsTypeset) -> Union[Dict[str, T], 
 
 def compare_detect_inference_frame(
     data: Sequence, typeset: VisionsTypeset
-) -> List[Tuple[str, T, T]]:
+) -> list[tuple[str, T, T]]:
     """Compare the types given by inference on the base graph and the relational graph
 
     Args:

--- a/src/visions/test/series.py
+++ b/src/visions/test/series.py
@@ -3,7 +3,7 @@ from typing import Dict
 import pandas as pd
 
 
-def get_series() -> Dict[str, pd.Series]:
+def get_series() -> dict[str, pd.Series]:
     from visions.backends.numpy.sequences import get_sequences as get_numpy_sequences
     from visions.backends.pandas.sequences import get_sequences as get_pandas_sequences
     from visions.backends.python.sequences import get_sequences as get_builtin_sequences

--- a/src/visions/test/series_geometry.py
+++ b/src/visions/test/series_geometry.py
@@ -3,7 +3,7 @@ from typing import Dict
 import pandas as pd
 
 
-def get_geometry_series() -> Dict[str, pd.Series]:
+def get_geometry_series() -> dict[str, pd.Series]:
     from shapely import wkt
 
     series = {

--- a/src/visions/test/series_sparse.py
+++ b/src/visions/test/series_sparse.py
@@ -10,7 +10,7 @@ not_pandas_1_0_5 = not (
 )
 
 
-def get_sparse_series() -> Dict[str, pd.Series]:
+def get_sparse_series() -> dict[str, pd.Series]:
     test_series = {
         "int_sparse": pd.Series([-1, 0, 1, 2, 3], dtype=pd.SparseDtype(np.int32, 0)),
         "float_sparse": pd.Series(

--- a/src/visions/test/utils.py
+++ b/src/visions/test/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Iterable, Optional, Sequence, Set, Tuple, Type
+from collections.abc import Iterable, Sequence
+from typing import Any, Dict, Optional, Set, Tuple, Type
 
 import networkx as nx
 import pandas as pd
@@ -6,7 +7,7 @@ import pytest
 
 from visions import VisionsBaseType, VisionsTypeset
 
-T = Type[VisionsBaseType]
+T = type[VisionsBaseType]
 
 
 def is_iter(v: Any) -> bool:
@@ -25,7 +26,7 @@ def sequences_equal(s1: Sequence, s2: Sequence) -> bool:
 
 
 def all_series_included(
-    series_list: Dict[str, Sequence], series_map: Dict[T, Set[str]]
+    series_list: dict[str, Sequence], series_map: dict[T, set[str]]
 ):
     """Check that all names are indeed used"""
     used_names = {name for names in series_map.values() for name in names}
@@ -44,8 +45,8 @@ def all_series_included(
 
 
 def get_contains_cases(
-    _test_suite: Dict[str, Sequence],
-    _series_map: Dict[T, Set[str]],
+    _test_suite: dict[str, Sequence],
+    _series_map: dict[T, set[str]],
     typeset: VisionsTypeset,
 ):
     """Parametrize contains tests
@@ -71,7 +72,7 @@ def get_contains_cases(
     argsvalues = []
     for name, item in _test_suite.items():
         for type, series_list in _series_map.items():
-            args: Dict[str, Any] = {"id": f"{name} x {type}"}
+            args: dict[str, Any] = {"id": f"{name} x {type}"}
 
             member = name in series_list
             argsvalues.append(pytest.param(name, item, type, member, **args))
@@ -82,7 +83,7 @@ def get_contains_cases(
     }
 
 
-def contains(name: str, series: Sequence, type: T, member: bool) -> Tuple[bool, str]:
+def contains(name: str, series: Sequence, type: T, member: bool) -> tuple[bool, str]:
     return (
         member == (series in type),
         f"{name} in {type}; expected {member}, got {series in type}",
@@ -90,10 +91,10 @@ def contains(name: str, series: Sequence, type: T, member: bool) -> Tuple[bool, 
 
 
 def get_inference_cases(
-    _test_suite: Dict[str, Sequence],
-    inferred_series_type_map: Dict[str, T],
+    _test_suite: dict[str, Sequence],
+    inferred_series_type_map: dict[str, T],
     typeset: VisionsTypeset,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     argsvalues = []
     for name, series in _test_suite.items():
         if name not in inferred_series_type_map:
@@ -104,7 +105,7 @@ def get_inference_cases(
         expected_type = inferred_series_type_map[name]
         for test_type in typeset.types:
             expected = test_type == expected_type
-            args: Dict[str, Any] = {"id": f"{name} x {test_type} expected {expected}"}
+            args: dict[str, Any] = {"id": f"{name} x {test_type} expected {expected}"}
             difference = test_type != expected_type
             argsvalues.append(
                 pytest.param(name, series, test_type, typeset, difference, **args)
@@ -121,7 +122,7 @@ def infers(
     expected_type: T,
     typeset: VisionsTypeset,
     difference: bool,
-) -> Tuple[bool, str]:
+) -> tuple[bool, str]:
     from visions.typesets.typeset import get_type_from_path
 
     _, paths, _ = typeset.infer(series)
@@ -174,7 +175,7 @@ def get_convert_cases(_test_suite, _series_map, typeset):
                     )
 
             if item in relation_type:
-                args: Dict[str, Any] = {
+                args: dict[str, Any] = {
                     "id": f"{name}: {relation_type} -> {source_type}"
                 }
                 member = name in series_list
@@ -190,7 +191,7 @@ def get_convert_cases(_test_suite, _series_map, typeset):
 
 def convert(
     name: str, source_type: T, relation_type: T, series: Sequence, member: bool
-) -> Tuple[bool, str]:
+) -> tuple[bool, str]:
     relation = source_type.relations.get(relation_type, None)
     is_relation = False if relation is None else relation.is_relation(series, {})
 
@@ -210,12 +211,12 @@ def convert(
         )
 
 
-def get_cast_cases(_test_suite: Dict[str, Sequence], _results: Dict) -> Dict:
+def get_cast_cases(_test_suite: dict[str, Sequence], _results: dict) -> dict:
     argsvalues = []
     for name, item in _test_suite.items():
         changed = name in _results
         value = _results.get(name, "")
-        args: Dict[str, Any] = {"id": f"{name}: {changed}"}
+        args: dict[str, Any] = {"id": f"{name}: {changed}"}
         argsvalues.append(pytest.param(name, item, value, **args))
 
     return dict(
@@ -229,7 +230,7 @@ def cast(
     series: Sequence,
     typeset: VisionsTypeset,
     expected: Optional[pd.Series] = None,
-) -> Tuple[bool, str]:
+) -> tuple[bool, str]:
     result = typeset.cast_to_inferred(series)
     # TODO: if error also print Path
     if expected is None:

--- a/src/visions/types/boolean.py
+++ b/src/visions/types/boolean.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/categorical.py
+++ b/src/visions/types/categorical.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/complex.py
+++ b/src/visions/types/complex.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/count.py
+++ b/src/visions/types/count.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/date.py
+++ b/src/visions/types/date.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/date_time.py
+++ b/src/visions/types/date_time.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/email_address.py
+++ b/src/visions/types/email_address.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import attr
 from multimethod import multimethod

--- a/src/visions/types/file.py
+++ b/src/visions/types/file.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/float.py
+++ b/src/visions/types/float.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/generic.py
+++ b/src/visions/types/generic.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/geometry.py
+++ b/src/visions/types/geometry.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/image.py
+++ b/src/visions/types/image.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/integer.py
+++ b/src/visions/types/integer.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/ip_address.py
+++ b/src/visions/types/ip_address.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/numeric.py
+++ b/src/visions/types/numeric.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/object.py
+++ b/src/visions/types/object.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/ordinal.py
+++ b/src/visions/types/ordinal.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/path.py
+++ b/src/visions/types/path.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/sparse.py
+++ b/src/visions/types/sparse.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/string.py
+++ b/src/visions/types/string.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/time.py
+++ b/src/visions/types/time.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/time_delta.py
+++ b/src/visions/types/time_delta.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/type.py
+++ b/src/visions/types/type.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, Optional, Sequence, Type, Union, cast
+from collections.abc import Sequence
+from typing import Any, Dict, Optional, Type, Union, cast
 
 import attr
 from multimethod import multimethod
@@ -13,7 +14,7 @@ class RelationsIterManager:
     """Class to enable to treat relations as dict"""
 
     def __init__(self, relations: Sequence[TypeRelation]):
-        self._keys: Dict["Type[VisionsBaseType]", int] = {
+        self._keys: dict["Type[VisionsBaseType]", int] = {
             item.related_type: i for i, item in enumerate(relations)
         }
         self.values = tuple(relations)

--- a/src/visions/types/url.py
+++ b/src/visions/types/url.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/types/uuid.py
+++ b/src/visions/types/uuid.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from multimethod import multimethod
 

--- a/src/visions/typesets/typeset.py
+++ b/src/visions/typesets/typeset.py
@@ -1,19 +1,8 @@
 import warnings
+from collections.abc import Iterable, Sequence
 from functools import singledispatch
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 import networkx as nx
 import pandas as pd
@@ -21,15 +10,15 @@ import pandas as pd
 from visions.types.generic import Generic
 from visions.types.type import VisionsBaseType
 
-TypeOrTypeset = TypeVar("TypeOrTypeset", Type[VisionsBaseType], "VisionsTypeset")
+TypeOrTypeset = TypeVar("TypeOrTypeset", type[VisionsBaseType], "VisionsTypeset")
 pathTypes = TypeVar(
-    "pathTypes", Type[VisionsBaseType], Dict[str, Type[VisionsBaseType]]
+    "pathTypes", type[VisionsBaseType], dict[str, type[VisionsBaseType]]
 )
 pdT = TypeVar("pdT", pd.Series, pd.DataFrame)
-T = Type[VisionsBaseType]
+T = type[VisionsBaseType]
 
 
-def build_graph(nodes: Set[Type[VisionsBaseType]]) -> Tuple[nx.DiGraph, nx.DiGraph]:
+def build_graph(nodes: set[type[VisionsBaseType]]) -> tuple[nx.DiGraph, nx.DiGraph]:
     """Constructs a traversable relation graph between visions types
 
     Builds a type relation graph from a collection of :class:`visions.types.type.VisionsBaseType` where
@@ -118,9 +107,9 @@ def traverse_graph_with_series(
     base_type: T,
     series: Sequence,
     graph: nx.DiGraph,
-    path: List[T] = None,
+    path: list[T] = None,
     state: Optional[dict] = None,
-) -> Tuple[Sequence, List[T], dict]:
+) -> tuple[Sequence, list[T], dict]:
     """Depth First Search traversal. There should be at most one successor that contains the series.
 
     Args:
@@ -157,7 +146,7 @@ def traverse_graph_with_sampled_series(
     graph: nx.DiGraph,
     sample_size: int = 10,
     state: dict = dict(),
-) -> Tuple[Sequence, List[T], dict]:
+) -> tuple[Sequence, list[T], dict]:
     """Depth First Search traversal with sampling. There should be at most one successor that contains the series.
 
     Args:
@@ -196,14 +185,14 @@ def traverse_graph_with_sampled_series(
 @singledispatch
 def traverse_graph(
     data: Sequence, root_node: T, graph: nx.DiGraph
-) -> Tuple[Sequence, Union[List[T], Dict[str, List[T]]], Dict[str, dict]]:
+) -> tuple[Sequence, Union[list[T], dict[str, list[T]]], dict[str, dict]]:
     return traverse_graph_with_series(root_node, data, graph)
 
 
 @singledispatch
 def get_type_from_path(
-    path_data: Union[Sequence[T], Dict[str, Sequence[T]]],
-) -> Union[T, Dict[str, T]]:
+    path_data: Union[Sequence[T], dict[str, Sequence[T]]],
+) -> Union[T, dict[str, T]]:
     raise TypeError(f"Can't get types from path object of type {type(path_data)}")
 
 
@@ -214,7 +203,7 @@ def _get_type_from_path_builtin(path_list: Sequence[T]) -> T:
 
 
 @get_type_from_path.register(dict)
-def _get_type_from_path_dict(path_dict: Dict[str, Sequence[T]]) -> Dict[str, T]:
+def _get_type_from_path_dict(path_dict: dict[str, Sequence[T]]) -> dict[str, T]:
     return {k: v[-1] for k, v in path_dict.items()}
 
 
@@ -229,7 +218,7 @@ class VisionsTypeset:
             and :class:`visions.relations.relations.InferenceRelation`
     """
 
-    def __init__(self, types: Set[Type[VisionsBaseType]]) -> None:
+    def __init__(self, types: set[type[VisionsBaseType]]) -> None:
         """
         Args:
             types: a set of types
@@ -259,7 +248,7 @@ class VisionsTypeset:
             self._root_node = next(nx.topological_sort(self.relation_graph))
         return self._root_node
 
-    def detect(self, data: Any) -> Tuple[Sequence, Any, dict]:
+    def detect(self, data: Any) -> tuple[Sequence, Any, dict]:
         """The results found after only considering IdentityRelations.
 
         Notes:
@@ -273,7 +262,7 @@ class VisionsTypeset:
         """
         return traverse_graph(data, self.root_node, self.base_graph)
 
-    def detect_type(self, data: Sequence) -> Union[T, Dict[str, T]]:
+    def detect_type(self, data: Sequence) -> Union[T, dict[str, T]]:
         """The inferred type found only considering IdentityRelations.
 
         Args:
@@ -285,7 +274,7 @@ class VisionsTypeset:
         _, paths, _ = self.detect(data)
         return get_type_from_path(paths)
 
-    def infer(self, data: Sequence) -> Tuple[Sequence, Any, dict]:
+    def infer(self, data: Sequence) -> tuple[Sequence, Any, dict]:
         """The results found after considering all relations.
 
         Notes:
@@ -299,7 +288,7 @@ class VisionsTypeset:
         """
         return traverse_graph(data, self.root_node, self.relation_graph)
 
-    def infer_type(self, data: Sequence) -> Union[T, Dict[str, T]]:
+    def infer_type(self, data: Sequence) -> Union[T, dict[str, T]]:
         """The inferred type found using all type relations.
 
         Args:
@@ -366,7 +355,7 @@ class VisionsTypeset:
         self,
         dpi: int = 800,
         base_only: bool = False,
-        figsize: Optional[Tuple[int, int]] = None,
+        figsize: Optional[tuple[int, int]] = None,
     ):
         """
 
@@ -391,7 +380,7 @@ class VisionsTypeset:
             plt.imshow(img)
         os.unlink(temp_file.name)
 
-    def _get_other_type(self, other: TypeOrTypeset) -> Set[T]:
+    def _get_other_type(self, other: TypeOrTypeset) -> set[T]:
         """Converts input into a set of :class:`visions.types.type.VisionsBaseType`
 
         Args:

--- a/src/visions/utils/images/image_utils.py
+++ b/src/visions/utils/images/image_utils.py
@@ -41,7 +41,7 @@ def is_image_truncated(image: Image) -> bool:
         return True
 
 
-def get_image_shape(image: Image) -> Optional[Tuple[int, int]]:
+def get_image_shape(image: Image) -> Optional[tuple[int, int]]:
     """
 
     Args:

--- a/src/visions/utils/monkeypatches/__init__.py
+++ b/src/visions/utils/monkeypatches/__init__.py
@@ -1,11 +1,11 @@
-from visions.utils.images.image_utils import HAS_IMGHDR
+from visions.utils.images.image_utils import HAS_IMGHDR, HAS_PUREMAGIC
 from visions.utils.monkeypatches import pathlib_patch
 
 __all__ = [
     "pathlib_patch",
 ]
 
-if HAS_IMGHDR:
+if HAS_IMGHDR and not HAS_PUREMAGIC:
     from visions.utils.monkeypatches import imghdr_patch
 
     __all__.append("imghdr_patch")

--- a/tests/pandas_/typesets/test_standard_set_sparse.py
+++ b/tests/pandas_/typesets/test_standard_set_sparse.py
@@ -27,7 +27,7 @@ series = get_sparse_series()
 
 typeset = StandardSet()
 
-contains_map: Dict[Type[VisionsBaseType], Set[str]] = {
+contains_map: dict[type[VisionsBaseType], set[str]] = {
     DateTime: set(),
     TimeDelta: set(),
     Categorical: set(),
@@ -75,7 +75,7 @@ def test_contains(name, series, contains_type, member):
     assert result, message
 
 
-inference_map: Dict[str, Type[VisionsBaseType]] = {
+inference_map: dict[str, type[VisionsBaseType]] = {
     "int_sparse": Integer,
     "pd_int64_sparse": Integer,
     "float_sparse": Float,

--- a/tests/python_/typesets/test_python_standard_set.py
+++ b/tests/python_/typesets/test_python_standard_set.py
@@ -31,7 +31,7 @@ sequences = get_sequences()
 
 typeset = StandardSet()
 
-contains_map: Dict[Type[VisionsBaseType], Set[str]] = {
+contains_map: dict[type[VisionsBaseType], set[str]] = {
     Integer: {
         "int_series",
         "int_range",

--- a/tests/test_declarative.py
+++ b/tests/test_declarative.py
@@ -41,7 +41,7 @@ def test_declarative():
 
     my_typeset = VisionsTypeset({Generic, Integer, Float})
 
-    array = np.arange(1, 100).astype(np.floating)
+    array = np.arange(1, 100).astype(np.float64)
 
     assert my_typeset.detect_type(array) == Float
     assert my_typeset.infer_type(array) == Integer


### PR DESCRIPTION
## Summary

* Replace deprecated pandas categorical dtype checks with an import-time compatibility helper.
* Use pandas 2+ datetime parsing behavior via format="mixed".
* Replace np.floating casts with np.float64 for NumPy 2.x compatibility.
* Handle Shapely parse exception compatibility at import time and avoid leaking redirected stderr.
* Prefer puremagic over the deprecated imghdr path when available.
* Fix pandas sparse string detection for pandas 3 / Arrow-backed string behavior.
* Bump package version to 0.8.2, set requires-python >=3.9, and add Python 3.14 classifier.
